### PR TITLE
Stable sorting links for better parallel edge handling

### DIFF
--- a/src/sankey.js
+++ b/src/sankey.js
@@ -87,11 +87,12 @@ export default function() {
       node.sourceLinks = [];
       node.targetLinks = [];
     });
-    links.forEach(function(link) {
+    links.forEach(function(link, i) {
       var source = link.source,
           target = link.target;
       if (typeof source === "number") source = link.source = nodes[link.source];
       if (typeof target === "number") target = link.target = nodes[link.target];
+      link.originalIndex = i;
       source.sourceLinks.push(link);
       target.targetLinks.push(link);
     });
@@ -278,11 +279,11 @@ export default function() {
     });
 
     function ascendingSourceDepth(a, b) {
-      return a.source.y - b.source.y;
+      return (a.source.y - b.source.y) || (a.originalIndex - b.originalIndex);
     }
 
     function ascendingTargetDepth(a, b) {
-      return a.target.y - b.target.y;
+      return (a.target.y - b.target.y) || (a.originalIndex - b.originalIndex);
     }
   }
 


### PR DESCRIPTION
Currently, link Y ordering is the result of non-stable sorting on both the source and target nodes, with the result that [multi-edges](https://en.wikipedia.org/wiki/Multiple_edges) may unnecessarily cross each other. By turning it into a stable short, via the use of an arbitrary but shareable (between source/target) tie breaker such as the original index of a link, we get better results.

![image](https://cloud.githubusercontent.com/assets/1548516/23454110/780c89fe-fe6b-11e6-86d2-ff46600f4ba1.png)

The dataset is from a data URL of [Washington Post - Fallen from the skies: drone crashes database](https://www.washingtonpost.com/graphics/national/drone-crashes/database/) which shows the utility of multi-edges (parallel links) for things like hover interactions and/or focus+context interactions. Attribute based coloring is yet another possibility.

All is not perfect though - the edges between the same source and target overlap slightly, depending on the Y offset between the anchor points and where we are on the line. This overlap may help or hinder the design, depending on goals, color and other styling.