### PR TITLE
Filled link path

### DIFF
--- a/src/sankey.js
+++ b/src/sankey.js
@@ -63,12 +63,19 @@ export default function() {
           xi = interpolateNumber(x0, x1),
           x2 = xi(curvature),
           x3 = xi(1 - curvature),
-          y0 = d.source.y + d.sy + d.dy / 2,
-          y1 = d.target.y + d.ty + d.dy / 2;
-      return "M" + x0 + "," + y0
-           + "C" + x2 + "," + y0
-           + " " + x3 + "," + y1
-           + " " + x1 + "," + y1;
+          y0a = d.source.y + d.sy,
+          y0b = y0a + d.dy,
+          y1a = d.target.y + d.ty,
+          y1b = y1a + d.dy;
+      return "M" + x0 + "," + y0a
+           + "C" + x2 + "," + y0a
+           + " " + x3 + "," + y1a
+           + " " + x1 + "," + y1a
+           + "L" + x1 + "," + y1b
+           + "C" + x3 + "," + y1b
+           + " " + x2 + "," + y0b
+           + " " + x0 + "," + y0b
+           + "Z";
     }
 
     link.curvature = function(_) {


### PR DESCRIPTION
Purports to solve these items:

- the circular artifacts around nodes when space for links is constrained, prominent with thick links
- partial overlap between adjacent links when using multiedges (multiple lines between the same pair of nodes, see https://github.com/d3/d3-sankey/pull/19) 
- allows styling of the link fill as well as the link stroke separately

A not particularly useful example, showing alignment of multi-edge link boundaries without gap or overlap (to reproduce the example, merge #19 also):
![image](https://cloud.githubusercontent.com/assets/1548516/25338667/501dc466-2900-11e7-91c7-41e1c8c57dcd.png)

The same, _without_ styling the link path `stroke`, i.e. just the fill:
![image](https://cloud.githubusercontent.com/assets/1548516/25338863/fa6df6a2-2900-11e7-92f3-80845a87e272.png)

The same, using a translucent black, to better show there are no disturbing gaps or overlaps - the same pairs of nodes are still multi-edges as above, and the nodes are moved vertically to stress test the link curves:
![image](https://cloud.githubusercontent.com/assets/1548516/25339020/8e68fffa-2901-11e7-94ba-f479c1687102.png)


There's also some loss:

- when the link is thick, and slope is steep, the link appears to be thinner in the middle than at the nodes - while layouting tries to avoid steep drops of strong connections, it's still an artifact that the `stroke-width` based logic doesn't have
- compatibility is broken - we _could_ introduce a separate method for the fill based link but in `D3`, usually code size consideration is important (also, it's in the `D3` org and made by Mike Bostock but isn't part of `D3` proper)
- it's no longer possible to tweak the former path width to subtly play with link width, or use a constant `stroke-width` instead of the usual `d.link.dy`