### PR TITLE
Fix NaN value in node.y0, node.y1, link.width, link.y0 and link.y1

### DIFF
--- a/src/sankey.js
+++ b/src/sankey.js
@@ -193,7 +193,7 @@ export default function() {
 
     function initializeNodeBreadth() {
       var ky = min(columns, function(nodes) {
-        return (y1 - y0 - (nodes.length - 1) * py) / sum(nodes, value);
+        return (y1 - y0 - (nodes.length - 1) * py) / Math.max(sum(nodes, value), 1);
       });
 
       columns.forEach(function(nodes) {
@@ -211,7 +211,7 @@ export default function() {
       columns.forEach(function(nodes) {
         nodes.forEach(function(node) {
           if (node.targetLinks.length) {
-            var dy = (sum(node.targetLinks, weightedSource) / sum(node.targetLinks, value) - nodeCenter(node)) * alpha;
+            var dy = (sum(node.targetLinks, weightedSource) / Math.max(sum(node.targetLinks, value), 1) - nodeCenter(node)) * alpha;
             node.y0 += dy, node.y1 += dy;
           }
         });
@@ -222,7 +222,7 @@ export default function() {
       columns.slice().reverse().forEach(function(nodes) {
         nodes.forEach(function(node) {
           if (node.sourceLinks.length) {
-            var dy = (sum(node.sourceLinks, weightedTarget) / sum(node.sourceLinks, value) - nodeCenter(node)) * alpha;
+            var dy = (sum(node.sourceLinks, weightedTarget) / Math.max(sum(node.sourceLinks, value), 1) - nodeCenter(node)) * alpha;
             node.y0 += dy, node.y1 += dy;
           }
         });


### PR DESCRIPTION
Steps to reproduce:
When value is zero for all links


`Error: <path> attribute d: Expected number, "M28,NaNC398.75,NaN,3…".
(anonymous) @ d3.js:1381
selection_each @ d3.js:1346
selection_attr @ d3.js:1403
Sankey._renderLinks @ sankey.ts:273
Sankey @ sankey.ts:596
`