### PR TITLE
Add sankey.nodeSort

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ If *align* is specified, sets the node [alignment method](#alignments) to the sp
 
 <a name="sankey_nodeSort" href="#sankey_nodeSort">#</a> <i>sankey</i>.<b>nodeSort</b>([<i>sort</i>]) [<>](https://github.com/d3/d3-sankey/blob/master/src/sankey.js#L86 "Source")
 
-If *sort* is specified, sets the node sort method to the specified function and returns this Sankey generator. If *sort* is not specified, returns the current node sort method. The specified function is used to set the vertical order of nodes in any given column, being passed two *node*s, and must return a number, which if is less than 0 places the first node above the second, and if greater than 0 places the second node above the first.
+If *sort* is specified, sets the node sort method to the specified function and returns this Sankey generator. If *sort* is not specified, returns the current node sort method, or *undefined* if node sorting is disabled. The specified function is used to set the vertical order of nodes in any given column, being passed two *node*s, and must return a number, which if is less than 0 places the first node above the second, and if greater than 0 places the second node above the first. Specifying *undefined*, or any value that is not a function, will disable sorting and display nodes in the order specified in the source array.
 
 <a name="sankey_nodeWidth" href="#sankey_nodeWidth">#</a> <i>sankey</i>.<b>nodeWidth</b>([<i>width</i>]) [<>](https://github.com/d3/d3-sankey/blob/master/src/sankey.js#L90 "Source")
 

--- a/README.md
+++ b/README.md
@@ -147,23 +147,27 @@ var links = [
 
 This is particularly useful when representing graphs in JSON, as JSON does not allow references. See [this example](https://bl.ocks.org/mbostock/f584aa36df54c451c94a9d0798caed35).
 
-<a name="sankey_nodeAlign" href="#sankey_nodeAlign">#</a> <i>sankey</i>.<b>nodeAlign</b>([<i>align</i>]) [<>](https://github.com/d3/d3-sankey/blob/master/src/sankey.js#L81 "Source")
+<a name="sankey_nodeAlign" href="#sankey_nodeAlign">#</a> <i>sankey</i>.<b>nodeAlign</b>([<i>align</i>]) [<>](https://github.com/d3/d3-sankey/blob/master/src/sankey.js#L82 "Source")
 
-If *align* is specified, sets the node [alignment method](#alignments) the specified function and returns this Sankey generator. If *align* is not specified, returns the current node alignment method, which defaults to [d3.sankeyJustify](#sankeyJustify). The specified function is evaluated for each input *node* in order, being passed the current *node* and the total depth *n* of the graph (one plus the maximum *node*.depth), and must return an integer between 0 and *n* - 1 that indicates the desired horizontal position of the node in the generated Sankey diagram.
+If *align* is specified, sets the node [alignment method](#alignments) to the specified function and returns this Sankey generator. If *align* is not specified, returns the current node alignment method, which defaults to [d3.sankeyJustify](#sankeyJustify). The specified function is evaluated for each input *node* in order, being passed the current *node* and the total depth *n* of the graph (one plus the maximum *node*.depth), and must return an integer between 0 and *n* - 1 that indicates the desired horizontal position of the node in the generated Sankey diagram.
 
-<a name="sankey_nodeWidth" href="#sankey_nodeWidth">#</a> <i>sankey</i>.<b>nodeWidth</b>([<i>width</i>]) [<>](https://github.com/d3/d3-sankey/blob/master/src/sankey.js#L85 "Source")
+<a name="sankey_nodeSort" href="#sankey_nodeSort">#</a> <i>sankey</i>.<b>nodeSort</b>([<i>sort</i>]) [<>](https://github.com/d3/d3-sankey/blob/master/src/sankey.js#L86 "Source")
+
+If *sort* is specified, sets the node sort method to the specified function and returns this Sankey generator. If *sort* is not specified, returns the current node sort method. The specified function is used to set the vertical order of nodes in any given column, being passed two *node*s, and must return a number, which if is less than 0 places the first node above the second, and if greater than 0 places the second node above the first.
+
+<a name="sankey_nodeWidth" href="#sankey_nodeWidth">#</a> <i>sankey</i>.<b>nodeWidth</b>([<i>width</i>]) [<>](https://github.com/d3/d3-sankey/blob/master/src/sankey.js#L90 "Source")
 
 If *width* is specified, sets the node width to the specified number and returns this Sankey generator. If *width* is not specified, returns the current node width, which defaults to 24.
 
-<a name="sankey_nodePadding" href="#sankey_nodePadding">#</a> <i>sankey</i>.<b>nodePadding</b>([<i>padding</i>]) [<>](https://github.com/d3/d3-sankey/blob/master/src/sankey.js#L89 "Source")
+<a name="sankey_nodePadding" href="#sankey_nodePadding">#</a> <i>sankey</i>.<b>nodePadding</b>([<i>padding</i>]) [<>](https://github.com/d3/d3-sankey/blob/master/src/sankey.js#L94 "Source")
 
 If *padding* is specified, sets the vertical separation between nodes at each column to the specified number and returns this Sankey generator. If *padding* is not specified, returns the current node padding, which defaults to 8.
 
-<a name="sankey_extent" href="#sankey_extent">#</a> <i>sankey</i>.<b>extent</b>([<i>extent</i>]) [<>](https://github.com/d3/d3-sankey/blob/master/src/sankey.js#L105 "Source")
+<a name="sankey_extent" href="#sankey_extent">#</a> <i>sankey</i>.<b>extent</b>([<i>extent</i>]) [<>](https://github.com/d3/d3-sankey/blob/master/src/sankey.js#L110 "Source")
 
 If *extent* is specified, sets the extent of the Sankey layout to the specified bounds and returns the layout. The *extent* bounds are specified as an array \[\[<i>x0</i>, <i>y0</i>\], \[<i>x1</i>, <i>y1</i>\]\], where *x0* is the left side of the extent, *y0* is the top, *x1* is the right and *y1* is the bottom. If *extent* is not specified, returns the current extent which defaults to [[0, 0], [1, 1]].
 
-<a name="sankey_size" href="#sankey_size">#</a> <i>sankey</i>.<b>size</b>([<i>size</i>]) [<>](https://github.com/d3/d3-sankey/blob/master/src/sankey.js#L101 "Source")
+<a name="sankey_size" href="#sankey_size">#</a> <i>sankey</i>.<b>size</b>([<i>size</i>]) [<>](https://github.com/d3/d3-sankey/blob/master/src/sankey.js#L106 "Source")
 
 An alias for [*sankey*.extent](#sankey_extent) where the minimum *x* and *y* of the extent are ⟨0,0⟩. Equivalent to:
 
@@ -171,7 +175,7 @@ An alias for [*sankey*.extent](#sankey_extent) where the minimum *x* and *y* of 
 sankey.extent([[0, 0], size]);
 ```
 
-<a name="sankey_iterations" href="#sankey_iterations">#</a> <i>sankey</i>.<b>iterations</b>([<i>iterations</i>]) [<>](https://github.com/d3/d3-sankey/blob/master/src/sankey.js#L109 "Source")
+<a name="sankey_iterations" href="#sankey_iterations">#</a> <i>sankey</i>.<b>iterations</b>([<i>iterations</i>]) [<>](https://github.com/d3/d3-sankey/blob/master/src/sankey.js#L114 "Source")
 
 If *iterations* is specified, sets the number of relaxation iterations when [generating the layout](#_sankey) and returns this Sankey generator. If *iterations* is not specified, returns the current number of relaxation iterations, which defaults to 32.
 

--- a/src/sankey.js
+++ b/src/sankey.js
@@ -55,6 +55,7 @@ export default function() {
       py = 8, // nodePadding
       id = defaultId,
       align = justify,
+      sort = ascendingBreadth,
       nodes = defaultNodes,
       links = defaultLinks,
       iterations = 32;
@@ -80,6 +81,10 @@ export default function() {
 
   sankey.nodeAlign = function(_) {
     return arguments.length ? (align = typeof _ === "function" ? _ : constant(_), sankey) : align;
+  };
+
+  sankey.nodeSort = function(_) {
+    return arguments.length ? (sort = typeof _ === "function" ? _ : constant(_), sankey) : sort;
   };
 
   sankey.nodeWidth = function(_) {
@@ -238,7 +243,7 @@ export default function() {
             i;
 
         // Push any overlapping nodes down.
-        nodes.sort(ascendingBreadth);
+        nodes.sort(sort);
         for (i = 0; i < n; ++i) {
           node = nodes[i];
           dy = y - node.y0;

--- a/src/sankey.js
+++ b/src/sankey.js
@@ -84,7 +84,7 @@ export default function() {
   };
 
   sankey.nodeSort = function(_) {
-    return arguments.length ? (sort = typeof _ === "function" ? _ : constant(_), sankey) : sort;
+    return arguments.length ? (sort = typeof _ === "function" ? _ : null, sankey) : sort;
   };
 
   sankey.nodeWidth = function(_) {
@@ -243,7 +243,9 @@ export default function() {
             i;
 
         // Push any overlapping nodes down.
-        nodes.sort(sort);
+        if (typeof sort === "function") {
+          nodes.sort(sort);
+        }
         for (i = 0; i < n; ++i) {
           node = nodes[i];
           dy = y - node.y0;

--- a/src/sankey.js
+++ b/src/sankey.js
@@ -84,7 +84,7 @@ export default function() {
   };
 
   sankey.nodeSort = function(_) {
-    return arguments.length ? (sort = typeof _ === "function" ? _ : null, sankey) : sort;
+    return arguments.length ? (sort = typeof _ === "function" ? _ : undefined, sankey) : sort;
   };
 
   sankey.nodeWidth = function(_) {
@@ -243,9 +243,7 @@ export default function() {
             i;
 
         // Push any overlapping nodes down.
-        if (typeof sort === "function") {
-          nodes.sort(sort);
-        }
+        if (typeof sort === "function") nodes.sort(sort);
         for (i = 0; i < n; ++i) {
           node = nodes[i];
           dy = y - node.y0;


### PR DESCRIPTION
This update enables users to override the default vertical sort order for nodes in any given column.

For example, if you need to sort all columns by `name`, you could use:

```javascript
sankey.nodeSort(function(nodeA, nodeB) {
    if (nodeA.name < nodeB.name) return -1;
    if (nodeA.name > nodeB.name) return 1;
    return 0;
});
```

This could equally be used to sort by `id` or `value`, or vertically group nodes together, depending on your required output.

Passing in a value of `undefined`, or any value that is not a function, will disable sorting and display nodes in the order specified in the source array:

```javascript
sankey.nodeSort(undefined);
```
