### PR TITLE
split linkSort into target-/sourceLinkSort

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,10 @@ For convenience, a link’s source and target may be initialized using numeric o
 * *link*.width - the link’s width (proportional to *link*.value)
 * *link*.index - the zero-based index of *link* within the array of links
 
-<a name="sankey_linkSort" href="#sankey_linkSort">#</a> <i>sankey</i>.<b>linkSort</b>([<i>sort</i>]) [<>](https://github.com/d3/d3-sankey/blob/master/src/sankey.js "Source")
-
-If *sort* is specified, sets the link sort method and returns this Sankey generator. If *sort* is not specified, returns the current link sort method, which defaults to *undefined*, indicating that vertical order of links within each node will be determined automatically by the layout. If *sort* is null, the order is fixed by the input. Otherwise, the specified *sort* function determines the order; the function is passed two links, and must return a value less than 0 if the first link should be above the second, and a value greater than 0 if the second link should be above the first, or 0 if the order is not specified.
+<a name="sankey_targetLinkSort" href="#sankey_targetLinkSort">#</a> <i>sankey</i>.<b>targetLinkSort</b>([<i>sort</i>]) [<>](https://github.com/d3/d3-sankey/blob/master/src/sankey.js "Source")
+<a name="sankey_sourceLinkSort" href="#sankey_sourceLinkSort">#</a> <i>sankey</i>.<b>sourceLinkSort</b>([<i>sort</i>]) [<>](https://github.com/d3/d3-sankey/blob/master/src/sankey.js "Source")  
+Allows to set a different sorting order for links at source node than at the target node.
+If _sort_ is specified, sets the link sort method and returns this Sankey generator. If _sort_ is not specified, returns the current link sort method, which defaults to _undefined_, indicating that vertical order of links within each node will be determined automatically by the layout. If _sort_ is null, the order is fixed by the input. Otherwise, the specified _sort_ function determines the order; the function is passed two links, and must return a value less than 0 if the first link should be above the second, and a value greater than 0 if the second link should be above the first, or 0 if the order is not specified.
 
 <a name="sankey_nodeId" href="#sankey_nodeId">#</a> <i>sankey</i>.<b>nodeId</b>([<i>id</i>]) [<>](https://github.com/d3/d3-sankey/blob/master/src/sankey.js "Source")
 

--- a/src/sankey.js
+++ b/src/sankey.js
@@ -58,7 +58,8 @@ export default function Sankey() {
   let id = defaultId;
   let align = justify;
   let sort;
-  let linkSort;
+  let targetLinkSort;
+  let sourceLinkSort;
   let nodes = defaultNodes;
   let links = defaultLinks;
   let iterations = 6;
@@ -107,8 +108,11 @@ export default function Sankey() {
     return arguments.length ? (links = typeof _ === "function" ? _ : constant(_), sankey) : links;
   };
 
-  sankey.linkSort = function(_) {
-    return arguments.length ? (linkSort = _, sankey) : linkSort;
+  sankey.targetLinkSort = function (_) {
+    return arguments.length ? ((targetLinkSort = _), sankey) : targetLinkSort;
+  };
+  sankey.sourceLinkSort = function (_) {
+    return arguments.length ? ((sourceLinkSort = _), sankey) : sourceLinkSort;
   };
 
   sankey.size = function(_) {
@@ -138,10 +142,14 @@ export default function Sankey() {
       source.sourceLinks.push(link);
       target.targetLinks.push(link);
     }
-    if (linkSort != null) {
-      for (const {sourceLinks, targetLinks} of nodes) {
-        sourceLinks.sort(linkSort);
-        targetLinks.sort(linkSort);
+    if (sourceLinkSort != null) {
+      for (const { sourceLinks } of nodes) {
+        sourceLinks.sort(sourceLinkSort);
+      }
+    }
+    if (targetLinkSort != null) {
+      for (const { targetLinks } of nodes) {
+        targetLinks.sort(targetLinkSort);
       }
     }
   }
@@ -317,22 +325,32 @@ export default function Sankey() {
     }
   }
 
-  function reorderNodeLinks({sourceLinks, targetLinks}) {
-    if (linkSort === undefined) {
-      for (const {source: {sourceLinks}} of targetLinks) {
-        sourceLinks.sort(ascendingTargetBreadth);
-      }
-      for (const {target: {targetLinks}} of sourceLinks) {
+  function reorderNodeLinks({ sourceLinks, targetLinks }) {
+    if (targetLinkSort === undefined) {
+      for (const {
+        target: { targetLinks },
+      } of sourceLinks) {
         targetLinks.sort(ascendingSourceBreadth);
+      }
+    }
+    if (sourceLinkSort === undefined) {
+      for (const {
+        source: { sourceLinks },
+      } of targetLinks) {
+        sourceLinks.sort(ascendingTargetBreadth);
       }
     }
   }
 
   function reorderLinks(nodes) {
-    if (linkSort === undefined) {
-      for (const {sourceLinks, targetLinks} of nodes) {
-        sourceLinks.sort(ascendingTargetBreadth);
+    if (targetLinkSort === undefined) {
+      for (const { targetLinks } of nodes) {
         targetLinks.sort(ascendingSourceBreadth);
+      }
+    }
+    if (sourceLinkSort === undefined) {
+      for (const { sourceLinks } of nodes) {
+        sourceLinks.sort(ascendingTargetBreadth);
       }
     }
   }


### PR DESCRIPTION
- allows to use different sorting order of links for target node than the one used for source node