### PR TITLE
adding minNodeHeight and maxNodeHeight config option

### DIFF
--- a/src/sankey.js
+++ b/src/sankey.js
@@ -235,7 +235,7 @@ export default function Sankey() {
         let mp = 1
         if (maxNodeHeight && nodeHeight > maxNodeHeight) {
           node.y1 = node.y1 - (nodeHeight - maxNodeHeight)
-          mp = nodeHeight / maxNodeHeight
+          mp = (nodeHeight / maxNodeHeight) * ky
         }
 
         y = node.y1 + py

--- a/src/sankey.js
+++ b/src/sankey.js
@@ -235,7 +235,8 @@ export default function Sankey() {
         let mp = 1
         if (maxNodeHeight && nodeHeight > maxNodeHeight) {
           node.y1 = node.y1 - (nodeHeight - maxNodeHeight)
-          mp = (nodeHeight / maxNodeHeight) * ky
+          mp = nodeHeight / maxNodeHeight
+          mp = ky > 1 ? mp * ky : mp / ky
         }
 
         y = node.y1 + py


### PR DESCRIPTION
This commit introduces two new configuration options, `minNodeHeight` and `maxNodeHeight`, allowing users to specify the minimum and maximum height for a node.


The addition of these options enhances the flexibility of our system by providing users with granular control over the vertical dimensions of individual nodes. This is particularly useful in scenarios where specific height constraints are necessary for layout and design considerations.

- Added `minNodeHeight` option to set the minimum height of a node.
- Added `maxNodeHeight` option to set the maximum height of a node.

## Example Usage
const sankey = d3.sankey()
  .nodeWidth(15)
  .nodePadding(10)
  .minNodeHeight(30)
  .maxNodeHeight(90);


